### PR TITLE
Attach anchor to DOM before triggering download

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,9 @@ window.addEventListener("load", function() {
     var a = document.createElement('a');
     a.download = "test-image.png";
     a.href = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAABC0lEQVQYlTXPPUsCYQDA8b/e04tdQR5ZBpE3NAR6S0SDVDZKDQ2BY9TUy1foE0TQ1Edo6hOEkyUG0QuBRtQgl0hnenVdnZD5eLbU7xv8Avy5X16KhrQBg47EtpziXO6qBhAEeNEm0qr7VdBcLxt2mlnNbhVu0NMAgdj1wvjOoX2xdSt0L7MGgx2GGid8yLrJvJMUkbKfOF8N68bUIqcz2wQR7GUcYvJIr1dFQijvkh89xGV6BPPMwvMF/nQXJMgWiM+KLPX2tc0HNa/HUxDv2owpx7xV+023Hiwpdt7yhmcjj9/NdrIhn8LrPVmotctWVd01Nt27wH9T3YhHU5O+sT/6SuVZKa4cNGoAv/ZMas7pC/KaAAAAAElFTkSuQmCC";
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
   }
 
   navigator.getUserMedia = (


### PR DESCRIPTION
Required to make the "automatic download" trigger in firefox (and chromium M65+  - see https://crbug.com/798676)