### PR TITLE
Remove min-height: 100% as it serves no benefit.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,6 @@
 /* Light material design boilerplate. */
 html, body {
   width: 100%;
-  min-height: 100%;
   margin: 0;
   padding: 0;
   background: #EEEEEE;


### PR DESCRIPTION
Having the min-height causes an extra blank page with printing when
in fullscreen in Chrome 69 and later. See https://crbug.com/862550