### PR TITLE
Apply min-height only to non-print media.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,10 +1,16 @@
 /* Light material design boilerplate. */
 html, body {
   width: 100%;
-  min-height: 100%;
   margin: 0;
   padding: 0;
   background: #EEEEEE;
+}
+
+/* Only apply min-height to non-print media */
+@media not print {
+  html, body {
+    min-height: 100%;
+  }
 }
 
 body {


### PR DESCRIPTION
Fixes issue when printing in fullscreen in Chrome there is a blank page.