### PR TITLE
Use `navigator.mediaDevices` if available

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 <button id="camera">Camera</button>
 <button id="microphone">Microphone</button>
 <button id="camera+microphone">Camera + Microphone</button>
+<button id="screenshare">Screen Share</button>
 <button id="midi">MIDI</button>
 <button id="bluetooth">Bluetooth</button>
 <button id="usb">USB</button>

--- a/index.js
+++ b/index.js
@@ -105,24 +105,48 @@ window.addEventListener("load", function() {
       );
     },
     "camera": function() {
-      navigator.getUserMedia(
-        {video: true},
-        displayOutcome("camera", "success"),
-        displayOutcome("camera", "error")
-      );
+      navigator.mediaDevices ?
+        navigator.mediaDevices.getUserMedia(
+          {video: true}).then(
+            displayOutcome("camera", "success"),
+            displayOutcome("camera", "error")
+        ) :
+        navigator.getUserMedia(
+          {video: true},
+          displayOutcome("camera", "success"),
+          displayOutcome("camera", "error")
+        );
     },
     "microphone": function() {
-      navigator.getUserMedia(
-        {audio: true},
-        displayOutcome("microphone", "success"),
-        displayOutcome("microphone", "error")
-      );
+      navigator.mediaDevices ?
+        navigator.mediaDevices.getUserMedia(
+          {audio: true}).then(
+            displayOutcome("microphone", "success"),
+            displayOutcome("microphone", "error")
+        ) :
+        navigator.getUserMedia(
+          {audio: true},
+          displayOutcome("microphone", "success"),
+          displayOutcome("microphone", "error")
+        );
     },
     "camera+microphone": function() {
-      navigator.getUserMedia(
-        {audio: true, video: true},
-        displayOutcome("camera+microphone", "success"),
-        displayOutcome("camera+microphone", "error")
+      navigator.mediaDevices ?
+        navigator.mediaDevices.getUserMedia(
+          {audio: true}).then(
+            displayOutcome("microphone", "success"),
+            displayOutcome("microphone", "error")
+        ) :
+        navigator.getUserMedia(
+          {audio: true, video: true},
+          displayOutcome("microphone", "success"),
+          displayOutcome("microphone", "error")
+        );
+    },
+    "screenshare": function() {
+      navigator.mediaDevices.getDisplayMedia().then(
+        displayOutcome("screenshare", "success"),
+        displayOutcome("screenshare", "error")
       );
     },
     "midi": function() {

--- a/index.js
+++ b/index.js
@@ -133,14 +133,14 @@ window.addEventListener("load", function() {
     "camera+microphone": function() {
       navigator.mediaDevices ?
         navigator.mediaDevices.getUserMedia(
-          {audio: true}).then(
-            displayOutcome("microphone", "success"),
-            displayOutcome("microphone", "error")
+          {audio: true, video: true}).then(
+            displayOutcome("camera+microphone", "success"),
+            displayOutcome("camera+microphone", "error")
         ) :
         navigator.getUserMedia(
           {audio: true, video: true},
-          displayOutcome("microphone", "success"),
-          displayOutcome("microphone", "error")
+          displayOutcome("camera+microphone", "success"),
+          displayOutcome("camera+microphone", "error")
         );
     },
     "screenshare": function() {


### PR DESCRIPTION
Use `navigator.mediaDevices` for camera/microphone if available, and add button to trigger screen sharing through `navigator.mediaDevices.getDisplayMedia`.