### PR TITLE
Add digital asset link to link this site to TWA.

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "org.chromium.twa.permissionsite",
+    "sha256_cert_fingerprints": [
+      "6A:54:B4:F8:E8:45:3F:83:C6:95:57:F6:74:E8:29:BD:A0:18:44:FC:8B:83:13:11:9F:AE:57:F2:D8:9C:1D:85"
+    ]
+  }
+}]


### PR DESCRIPTION
Add .well-known/assetlinks.json to link this site to a TWA for testing. See details at:
https://developers.google.com/web/updates/2019/02/using-twa