### PR TITLE
Add support for Web NFC

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 <button id="quota-management">Quota Management</button>
 <button id="protocol-handler">Protocol Handler</button>
 <button id="webauthn-attestation">WebAuthn Attestation</button>
+<button id="nfc">NFC</button>
 
 <button id="keygen">&lt;keygen&gt;</button>
 <div id="keygen-container"></div>
@@ -70,7 +71,12 @@
 <br><br><br>
 <p>Notes:</p>
 <table>
-<tr><td>Serial</td>
+<tr>
+  <td>NFC</td>
+  <td>Android only - Implemented behind the experimental flag <code>chrome://flags/#enable-webnfc</code>.</td>
+</tr>
+<tr>
+  <td>Serial</td>
   <td>Implemented behind the experimental flag <code>chrome://flags/#enable-experimental-web-platform-features</code>.</td>
 </tr>
 <tr><td>Encrypted Media (EME)</td>

--- a/index.js
+++ b/index.js
@@ -466,6 +466,10 @@ window.addEventListener("load", function() {
             displayOutcome("webauthn-attestation", "error")(err);
           });
     },
+    "nfc": function() {
+      const reader = new NFCReader();
+      reader.scan();
+    },
   };
 
   for (var type in register) {


### PR DESCRIPTION
This PR is about adding support for Web NFC so that web developers can play with the upcoming interstitial prompt.

Live preview is available at http://beaufortfrancois.github.io/permission.site/