### PR TITLE
Remove '_' in scheme

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,7 +367,7 @@ window.addEventListener("load", function() {
       // https://www.w3.org/TR/html5/webappapis.html#navigatorcontentutils
       var url = window.location + '%s';
       try {
-        navigator.registerProtocolHandler('web+permission.site', url, 'title');
+        navigator.registerProtocolHandler('web+permissionsite', url, 'title');
       } catch(e) {
         displayOutcome("protocol-handler", "error")(e);
       }


### PR DESCRIPTION
As described in https://html.spec.whatwg.org/multipage/system-state.html#normalize-protocol-handler-parameters, the scheme is not allowed to use `_`. This PR fixes this by removing it so that prompt is shown.

@engedy 