### PR TITLE
Remove notes for NFC, Serial, and HID

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,18 +81,6 @@
   <td>Augmented Reality (AR)</td>
   <td>Implemented behind the experimental flag <code>chrome://flags/#enable-experimental-web-platform-features</code>.</td>
 </tr>
-<tr>
-  <td>NFC</td>
-  <td>Android only - Implemented behind the experimental flag <code>chrome://flags/#enable-experimental-web-platform-features</code>.</td>
-</tr>
-<tr>
-  <td>Serial</td>
-  <td>Implemented behind the experimental flag <code>chrome://flags/#enable-experimental-web-platform-features</code>.</td>
-</tr>
-<tr>
-  <td>HID</td>
-  <td>Implemented behind the experimental flag <code>chrome://flags/#enable-experimental-web-platform-features</code>.</td>
-</tr>
 <tr><td>Encrypted Media (EME)</td>
   <td>May succeed without permission depending on the implementation.<br>
     Attempts to use known key systems. (See the source for the list of supported key systems.)


### PR DESCRIPTION
Once Chrome 89 is stable (2021 March), we can safely remove NFC, Serial, and HID notes as no flag are required anymore.