### PR TITLE
Fix confusing glimpse of 'Green' when clicking while in chrome dev tools emulator mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,12 @@
 </head>
 <body>
 
+<noscript>
+  <div class="jswarning">
+    This site does not function without JavaScript!
+  </div>
+</noscript>
+
 <div class="before"></div>
 <div class="content">
 

--- a/style.css
+++ b/style.css
@@ -174,3 +174,9 @@ a#toggle:hover {
   background-color: rgb(29, 194, 34);
   transform: translateX(20px);
 }
+
+.jswarning
+{
+  color: rgb(219, 68, 55);
+  font-size: 2em;
+}

--- a/style.css
+++ b/style.css
@@ -43,7 +43,6 @@ button {
 }
 button:hover {
   background: #FFA;
-  cursor: pointer;
   box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
   transform: translateY(-2px);
 }


### PR DESCRIPTION
Issue is caused by emulator putting a blue highlight box around the button. Changing the cursor to default fixes this and there isn't much lost since the button already highlight on hover.