### PR TITLE
Fix confusing green flash when tapping on button in chrome dev tools,…

### DIFF
--- a/style.css
+++ b/style.css
@@ -46,6 +46,7 @@ button:hover {
   cursor: pointer;
   box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
   transform: translateY(-2px);
+  -webkit-tap-highlight-color: transparent;
 }
 button.success {
   background: #AFA;


### PR DESCRIPTION
… mobile device simulator mode

This is a re-open of https://github.com/chromium/permission.site/pull/95 with a different approach and clean commit history.

`-webkit-tap-highlight-color` is non-standard but since the issue seems to be Chrome-specific I believe this should be fine.