### PR TITLE
Remove deprecated persistent quota behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,6 @@
 <button id="eme">Encrypted Media (EME)</button>
 <button id="idle-detection">Idle Detection</button>
 <button id="persistent-storage">Persistent Storage</button>
-<button id="quota-management">Quota Management</button>
 <button id="protocol-handler">Protocol Handler</button>
 <button id="webauthn-attestation">WebAuthn Attestation</button>
 <button id="nfc">NFC</button>

--- a/index.js
+++ b/index.js
@@ -382,20 +382,7 @@ window.addEventListener("load", function() {
         displayOutcome("persistent-storage", "error")
       )
     },
-    "quota-management": function() {
-      // https://www.w3.org/TR/2012/WD-quota-api-20120703/
-      navigator.webkitPersistentStorage.queryUsageAndQuota(
-        function(currentUsageInBytes, currentQuotaInBytes) {
-          var quota = currentQuotaInBytes + 1024 * 1024;
-          navigator.webkitPersistentStorage.requestQuota(quota,
-            function(newQuota) {
-              displayOutcome("quota-management", (newQuota == quota) ? "success" : "default")(newQuota);
-            },
-            displayOutcome("quota-management", "error"));
-        },
-        displayOutcome("quota-management", "error")
-      )
-    },
+    
     "protocol-handler": function() {
       // https://www.w3.org/TR/html5/webappapis.html#navigatorcontentutils
       var url = window.location + '%s';


### PR DESCRIPTION
This change removes the "Quota Management" button since its behavior is now deprecated.
Persistent quota behavior has been deprecated from M106 [0], therefore requesting quota
is no longer supported and will no longer show a pop-up permission.

[0] https://chromestatus.com/feature/5176235376246784
[1] crbug: https://crbug.com/1375990