### PR TITLE
Add MIDI + SysEx button and change MIDI button behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 <button id="pan-tilt-zoom+microphone">Pan-Tilt-Zoom + Microphone</button>
 <button id="screenshare">Screen Share</button>
 <button id="midi">MIDI</button>
+<button id="midi+sysex">MIDI + SysEx</button>
 <button id="bluetooth">Bluetooth</button>
 <button id="usb">USB</button>
 <button id="serial">Serial</button>

--- a/index.js
+++ b/index.js
@@ -177,10 +177,18 @@ window.addEventListener("load", function() {
     },
     "midi": function() {
       navigator.requestMIDIAccess({
-        sysex: true
+        sysex: false
       }).then(
         displayOutcome("midi", "success"),
         displayOutcome("midi", "error")
+      );
+    },
+    "midi+sysex": function() {
+      navigator.requestMIDIAccess({
+        sysex: true
+      }).then(
+        displayOutcome("midi+sysex", "success"),
+        displayOutcome("midi+sysex", "error")
       );
     },
     "bluetooth": function() {


### PR DESCRIPTION
We are starting work on gating all MIDI access behind a permissions prompt in Chromium, instead of the current behavior of only gating when SysEx use is requested.  I would like to add another button so we can verify the prompt behavior both when SysEx is requested and when it is not.

Specification: https://www.w3.org/TR/webmidi/#requestmidiaccess
Chromestatus: https://chromestatus.com/feature/5087054662205440
Tracking Bug: https://crbug.com/1420307
Firefox has implemented this already: https://bugzilla.mozilla.org/show_bug.cgi?id=1795025