### PR TITLE
Feat: Implemented onchange-based approach

### DIFF
--- a/one-time.js
+++ b/one-time.js
@@ -1,7 +1,7 @@
 const OTHER_PAGE_HREF = '/other-page.html';
 
 const PERMISSIONS_API_STATUSES = {
-  // status ID: status display string
+  // key = status ID, value: user-friendly string to display
   granted: '🟢 granted',
   denied: '🔴 denied',
   prompt: '🔵 prompt',
@@ -12,22 +12,7 @@ const API_ACCESS_STATUSES = {
   error: '🔴 error',
 };
 
-// Permissions API status
-function updatePermissionsApiStatus(permissionName) {
-  navigator.permissions.query({ name: permissionName }).then(
-    (result) => {
-      const { state } = result;
-      const displayStatus = PERMISSIONS_API_STATUSES[state];
-      document.querySelector(`#${permissionName}-permission-status`).innerText =
-        displayStatus;
-    },
-    // Rejected promise callback
-    () => {
-      console.warn(
-        `${permissionName}: In this browser, the status of this permission can't be queried via the Permissions API`
-      );
-    }
-  );
+// Display the Permissions API status (https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API)
 }
 
 // Feature access status


### PR DESCRIPTION
In this PR:
* Refactor/Docs: A few renaming and comments for clarity
* Feat: Implement `onchange` approach: I now change the Permissions API status _when it changes_ (and not on success/failure callback of whether API access was successful)
* Bugfix: Due to the previous bullet point, I also fix an issue where the Permissions API status was slow to update in the UI.

See screencasts below:

* Before the fix:
https://github.com/chromium/permission.site/assets/9762897/edb182b9-68f0-41ee-b3c6-d0fbc8ceec0d
* After the fix, the permission status updates immediately in the UI (and the access status a bit later which is expected):
https://github.com/chromium/permission.site/assets/9762897/37df8dcf-5495-4f67-9efb-c3bc66287fff

