### PR TITLE
Add <div> guards around <permission> elements

### DIFF
--- a/pepc.html
+++ b/pepc.html
@@ -11,10 +11,10 @@
   <body>  
     <div class="before"></div>
     <div class="content">
-      <permission id="geolocation" type="geolocation">
-      <permission id="camera" type="camera">
-      <permission id="microphone" type="microphone">
-      <permission id="camera-microphone" type="camera microphone">
+      <div><permission id="geolocation" type="geolocation"></div>
+      <div><permission id="camera" type="camera"></div>
+      <div><permission id="microphone" type="microphone"></div>
+      <div><permission id="camera-microphone" type="camera microphone"></div>
     </div>
     <div class="github-fork-ribbon-wrapper right">
       <div class="github-fork-ribbon">


### PR DESCRIPTION
This allows user agents without knowledge of <permission> to correctly generate end tags without <permission> elements becoming nested into each other.