### PR TITLE
Color fullscreen, pointer, and keyboard lock buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,6 +367,8 @@ window.addEventListener("load", function() {
           document.exitFullscreen().then(
             displayOutcome("fullscreen", "default"),
             displayOutcome("fullscreen", "error"));
+          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default"));
+          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error"));
         } else {
           document.documentElement.requestFullscreen().then(
             displayOutcome("fullscreen", "success"),
@@ -386,15 +388,13 @@ window.addEventListener("load", function() {
         if (!window.keyboardLockRequested) {
           // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
           navigator.keyboard.lock().then(
-            displayOutcome("keyboardlock", "success"),
+            displayOutcome("keyboardlock", "success")(document.fullscreenElement ? "Locked" : "Will lock in fullscreen"),
             displayOutcome("keyboardlock", "error")
           );
           window.keyboardLockRequested = true;
         } else {
-          navigator.keyboard.unlock().then(
-            displayOutcome("keyboardlock", "default"),
-            displayOutcome("keyboardlock", "error")
-          );
+          navigator.keyboard.unlock();
+          displayOutcome("keyboardlock", "default")();
           window.keyboardLockRequested = false;
         }
       } catch (e) {

--- a/index.js
+++ b/index.js
@@ -364,9 +364,13 @@ window.addEventListener("load", function() {
     "fullscreen": function() {
       try {
         if (document.fullscreenElement) {
-          document.exitFullscreen().then(() => { displayOutcome("fullscreen", "default") });
+          document.exitFullscreen().then(
+            displayOutcome("fullscreen", "default"),
+            displayOutcome("fullscreen", "error"));
         } else {
-          document.documentElement.requestFullscreen().then(() => { displayOutcome("fullscreen", "success") });
+          document.documentElement.requestFullscreen().then(
+            displayOutcome("fullscreen", "success"),
+            displayOutcome("fullscreen", "error"));
         }
       } catch (e) {
         displayOutcome("fullscreen", "error")(e);
@@ -380,18 +384,18 @@ window.addEventListener("load", function() {
     "keyboardlock": function() {
       try {
         if (!window.keyboardLockRequested) {
-          navigator.keyboard.lock().then(() => {
-            window.keyboardLockRequested = true;
-            // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
-            displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
-            document.addEventListener("fullscreenchange", (event) => {
-              displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
-            });
-          }).catch(() => { displayOutcome("keyboardlock", "error"); });
+          // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
+          navigator.keyboard.lock().then(
+            displayOutcome("keyboardlock", "success"),
+            displayOutcome("keyboardlock", "error")
+          );
+          window.keyboardLockRequested = true;
         } else {
+          navigator.keyboard.unlock().then(
+            displayOutcome("keyboardlock", "default"),
+            displayOutcome("keyboardlock", "error")
+          );
           window.keyboardLockRequested = false;
-          displayOutcome("keyboardlock", "default");
-          navigator.keyboard.unlock();
         }
       } catch (e) {
         displayOutcome("keyboardlock", "error")(e);

--- a/index.js
+++ b/index.js
@@ -364,8 +364,8 @@ window.addEventListener("load", function() {
     "fullscreen": function() {
       try {
         if (!document.fullscreenElement) {
-          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")("change event"));
-          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error event"));
+          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default"));
+          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error"));
           document.documentElement.requestFullscreen().then(
             displayOutcome("fullscreen", "success")("enter"),
             displayOutcome("fullscreen", "error")
@@ -384,8 +384,8 @@ window.addEventListener("load", function() {
       try {
         if (!window.pointerLockRequested) {
           window.pointerLockRequested = true;
-          document.addEventListener("pointerlockchange", displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default")("change event"));
-          document.addEventListener("pointerlockerror", displayOutcome("pointerlock", "error event"));
+          document.addEventListener("pointerlockchange", displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default"));
+          document.addEventListener("pointerlockerror", displayOutcome("pointerlock", "error"));
           document.body.requestPointerLock().then(
             displayOutcome("pointerlock", "success")("locked"),
             displayOutcome("pointerlock", "error")
@@ -403,7 +403,7 @@ window.addEventListener("load", function() {
       try {
         if (!window.keyboardLockRequested) {
           window.keyboardLockRequested = true;
-          // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
+          // Note: As of 2023-12-13, Chrome resolves the promise immediately and holds the lock in a pending state when the document is not fullscreen.
           navigator.keyboard.lock().then(
             displayOutcome("keyboardlock", "success")(document.fullscreenElement ? "locked" : "will lock in fullscreen"),
             displayOutcome("keyboardlock", "error")

--- a/index.js
+++ b/index.js
@@ -365,13 +365,13 @@ window.addEventListener("load", function() {
       try {
         if (document.fullscreenElement) {
           document.exitFullscreen().then(
-            displayOutcome("fullscreen", "default"),
+            displayOutcome("fullscreen", "default")("exited with API"),
             displayOutcome("fullscreen", "error"));
-          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default"));
+          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")(document.fullscreenElement ? "fullscreenchanged enter" : "fullscreenchanged on exit"));
           document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error"));
         } else {
           document.documentElement.requestFullscreen().then(
-            displayOutcome("fullscreen", "success"),
+            displayOutcome("fullscreen", "success")("entered"),
             displayOutcome("fullscreen", "error"));
         }
       } catch (e) {
@@ -394,7 +394,7 @@ window.addEventListener("load", function() {
           window.keyboardLockRequested = true;
         } else {
           navigator.keyboard.unlock();
-          displayOutcome("keyboardlock", "default")();
+          displayOutcome("keyboardlock", "default")("unlocked");
           window.keyboardLockRequested = false;
         }
       } catch (e) {

--- a/index.js
+++ b/index.js
@@ -61,17 +61,25 @@ window.addEventListener("load", function() {
     a.click();
   }
 
+  function isFullscreen() {
+    return document.fullscreenElement ||
+           document.webkitFullscreenElement ||
+           document.mozFullScreenElement ||
+           document.msFullscreenElement;
+  }
+
+  function isPointerLocked() {
+    return document.pointerLockElement ||
+           document.webkitPointerLockElement ||
+           document.mozPointerLockElement ||
+           document.msPointerLockElement;
+  }
+
   navigator.getUserMedia = (
     navigator.getUserMedia ||
     navigator.webkitGetUserMedia ||
     navigator.mozGetUserMedia ||
     navigator.msGetUserMedia
-  );
-  navigator.requestFullscreen = (
-    navigator.requestFullscreen ||
-    navigator.webkitRequestFullscreen ||
-    navigator.mozRequestFullscreen ||
-    navigator.msRequestFullscreen
   );
   navigator.requestMIDIAccess = (
     navigator.requestMIDIAccess ||
@@ -79,11 +87,17 @@ window.addEventListener("load", function() {
     navigator.mozRequestMIDIAccess ||
     navigator.msRequestMIDIAccess
   );
-  document.body.requestFullScreen = (
-    document.body.requestFullScreen ||
-    document.body.webkitRequestFullScreen ||
-    document.body.mozRequestFullScreen ||
-    document.body.msRequestFullScreen
+  document.documentElement.requestFullscreen = (
+    document.documentElement.requestFullscreen ||
+    document.documentElement.webkitRequestFullscreen ||
+    document.documentElement.mozRequestFullscreen ||
+    document.documentElement.msRequestFullscreen
+  );
+  document.exitFullscreen = (
+    document.exitFullscreen ||
+    document.webkitExitFullscreen ||
+    document.mozCancelFullScreen ||
+    document.msExitFullscreen
   );
   document.body.requestPointerLock = (
     document.body.requestPointerLock ||
@@ -91,6 +105,25 @@ window.addEventListener("load", function() {
     document.body.mozRequestPointerLock ||
     document.body.msRequestPointerLock
   );
+  document.exitPointerLock = (
+    document.exitPointerLock ||
+    document.webkitExitPointerLock ||
+    document.mozExitPointerLock ||
+    document.msExitPointerLock
+  );
+
+  document.addEventListener("fullscreenchange", (e) => {
+    displayOutcome("fullscreen", isFullscreen() ? "success" : "default")(e);
+  });
+  document.addEventListener("fullscreenerror", (e) => {
+    displayOutcome("fullscreen", "error")(e);
+  });
+  document.addEventListener("pointerlockchange", (e) => {
+    displayOutcome("pointerlock", isPointerLocked() ? "success" : "default")(e);
+  });
+  document.addEventListener("pointerlockerror", (e) => {
+    displayOutcome("pointerlock", "error")(e);
+  });
 
   var register = {
     "notifications": function () {
@@ -363,13 +396,7 @@ window.addEventListener("load", function() {
     },
     "fullscreen": function() {
       try {
-        if (!document.fullscreenElement) {
-          document.addEventListener("fullscreenchange", (e) => {
-            displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")(e);
-          });
-          document.addEventListener("fullscreenerror", (e) => {
-            displayOutcome("fullscreen", "error")(e);
-          });
+        if (!isFullscreen()) {
           document.documentElement.requestFullscreen().then(
             displayOutcome("fullscreen", "success")("enter"),
             displayOutcome("fullscreen", "error")
@@ -387,14 +414,6 @@ window.addEventListener("load", function() {
     "pointerlock": function() {
       try {
         if (!window.pointerLocked) {
-          document.addEventListener("pointerlockchange", (e) => {
-            window.pointerLocked = !window.pointerLocked;
-            displayOutcome("pointerlock", window.pointerLocked ? "success" : "default")(e);
-          });
-          document.addEventListener("pointerlockerror", (e) => {
-            window.pointerLocked = false;
-            displayOutcome("pointerlock", "error")(e);
-          });
           document.body.requestPointerLock().then(
             displayOutcome("pointerlock", "success")("locked"),
             displayOutcome("pointerlock", "error")
@@ -411,9 +430,9 @@ window.addEventListener("load", function() {
       try {
         if (!window.keyboardLockRequested) {
           window.keyboardLockRequested = true;
-          // Note: As of 2023-12-13, Chrome resolves the promise immediately and holds the lock in a pending state when the document is not fullscreen.
+          // Note: As of 2023-12-14, Chrome resolves the promise immediately and holds the lock in a pending state when the document is not fullscreen.
           navigator.keyboard.lock().then(
-            displayOutcome("keyboardlock", "success")(document.fullscreenElement ? "locked" : "will lock in fullscreen"),
+            displayOutcome("keyboardlock", "success")(isFullscreen() ? "locked" : "will lock in fullscreen"),
             displayOutcome("keyboardlock", "error")
           );
         } else {

--- a/index.js
+++ b/index.js
@@ -362,10 +362,15 @@ window.addEventListener("load", function() {
       }, 5000);
     },
     "fullscreen": function() {
-      // Note: As of 2014-12-16, fullscreen only allows "ask" and "allow" in Chrome.
-      document.body.requestFullScreen(
-        /* no callback */
-      );
+      try {
+        if (document.fullscreenElement) {
+          document.exitFullscreen().then(() => { displayOutcome("fullscreen", "default") });
+        } else {
+          document.documentElement.requestFullscreen().then(() => { displayOutcome("fullscreen", "success") });
+        }
+      } catch (e) {
+        displayOutcome("fullscreen", "error")(e);
+      }
     },
     "pointerlock": function() {
       document.body.requestPointerLock(
@@ -373,20 +378,23 @@ window.addEventListener("load", function() {
       );
     },
     "keyboardlock": function() {
-      // Track requested state manually.
-      if (!window.keyboardLockRequested) {
-        navigator.keyboard.lock().then(() => {
-          window.keyboardLockRequested = true;
-          // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
-          displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
-          document.addEventListener("fullscreenchange", (event) => {
+      try {
+        if (!window.keyboardLockRequested) {
+          navigator.keyboard.lock().then(() => {
+            window.keyboardLockRequested = true;
+            // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
             displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
-          });
-        }).catch(() => { displayOutcome("keyboardlock", "error"); });
-      } else {
-        window.keyboardLockRequested = false;
-        displayOutcome("keyboardlock", "default");
-        navigator.keyboard.unlock();
+            document.addEventListener("fullscreenchange", (event) => {
+              displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
+            });
+          }).catch(() => { displayOutcome("keyboardlock", "error"); });
+        } else {
+          window.keyboardLockRequested = false;
+          displayOutcome("keyboardlock", "default");
+          navigator.keyboard.unlock();
+        }
+      } catch (e) {
+        displayOutcome("keyboardlock", "error")(e);
       }
     },
     "download": function() {

--- a/index.js
+++ b/index.js
@@ -364,8 +364,12 @@ window.addEventListener("load", function() {
     "fullscreen": function() {
       try {
         if (!document.fullscreenElement) {
-          document.addEventListener("fullscreenchange", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default"));
-          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error"));
+          document.addEventListener("fullscreenchange", (e) => {
+            displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")(e);
+          });
+          document.addEventListener("fullscreenerror", (e) => {
+            displayOutcome("fullscreen", "error")(e);
+          });
           document.documentElement.requestFullscreen().then(
             displayOutcome("fullscreen", "success")("enter"),
             displayOutcome("fullscreen", "error")
@@ -382,16 +386,20 @@ window.addEventListener("load", function() {
     },
     "pointerlock": function() {
       try {
-        if (!window.pointerLockRequested) {
-          window.pointerLockRequested = true;
-          document.addEventListener("pointerlockchange", displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default"));
-          document.addEventListener("pointerlockerror", displayOutcome("pointerlock", "error"));
+        if (!window.pointerLocked) {
+          document.addEventListener("pointerlockchange", (e) => {
+            window.pointerLocked = !window.pointerLocked;
+            displayOutcome("pointerlock", window.pointerLocked ? "success" : "default")(e);
+          });
+          document.addEventListener("pointerlockerror", (e) => {
+            window.pointerLocked = false;
+            displayOutcome("pointerlock", "error")(e);
+          });
           document.body.requestPointerLock().then(
             displayOutcome("pointerlock", "success")("locked"),
             displayOutcome("pointerlock", "error")
           );
         } else {
-          window.pointerLockRequested = false;
           document.exitPointerLock();
           displayOutcome("pointerlock", "default")("unlocked");
         }

--- a/index.js
+++ b/index.js
@@ -373,7 +373,20 @@ window.addEventListener("load", function() {
       );
     },
     "keyboardlock": function() {
-      navigator.keyboard.lock();
+      // Track requested state manually.
+      if (!window.keyboardLockRequested) {
+        window.keyboardLockRequested = true;
+        navigator.keyboard.lock().then(() => {
+          // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
+          displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
+          const handleDeviceOrientation = () => document.addEventListener("fullscreenchange", (event) => {
+            displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
+          });
+        }).catch(() => { displayOutcome("keyboardlock", "error") });
+      } else {
+        window.keyboardLockRequested = false;
+        navigator.keyboard.unlock()
+      }
     },
     "download": function() {
       // Two downloads at the same time trigger a permission prompt in Chrome.

--- a/index.js
+++ b/index.js
@@ -364,8 +364,8 @@ window.addEventListener("load", function() {
     "fullscreen": function() {
       try {
         if (!document.fullscreenElement) {
-          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default"));
-          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error"));
+          document.addEventListener("fullscreenchanged", (e) => { displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")(e); });
+          document.addEventListener("fullscreenerror", (e) => { displayOutcome("fullscreen", "error")(e); });
           document.documentElement.requestFullscreen().then(
             displayOutcome("fullscreen", "success")("enter"),
             displayOutcome("fullscreen", "error")
@@ -384,8 +384,8 @@ window.addEventListener("load", function() {
       try {
         if (!window.pointerLockRequested) {
           window.pointerLockRequested = true;
-          document.addEventListener("pointerlockchange", displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default"));
-          document.addEventListener("pointerlockerror", displayOutcome("pointerlock", "error"));
+          document.addEventListener("pointerlockchange", (e) => { displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default")(e); });
+          document.addEventListener("pointerlockerror", (e) => { displayOutcome("pointerlock", "error")(e); });
           document.body.requestPointerLock().then(
             displayOutcome("pointerlock", "success")("locked"),
             displayOutcome("pointerlock", "error")

--- a/index.js
+++ b/index.js
@@ -375,17 +375,18 @@ window.addEventListener("load", function() {
     "keyboardlock": function() {
       // Track requested state manually.
       if (!window.keyboardLockRequested) {
-        window.keyboardLockRequested = true;
         navigator.keyboard.lock().then(() => {
+          window.keyboardLockRequested = true;
           // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
           displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
-          const handleDeviceOrientation = () => document.addEventListener("fullscreenchange", (event) => {
+          document.addEventListener("fullscreenchange", (event) => {
             displayOutcome("keyboardlock", document.fullscreenElement && window.keyboardLockRequested ? "success" : "default");
           });
-        }).catch(() => { displayOutcome("keyboardlock", "error") });
+        }).catch(() => { displayOutcome("keyboardlock", "error"); });
       } else {
         window.keyboardLockRequested = false;
-        navigator.keyboard.unlock()
+        displayOutcome("keyboardlock", "default");
+        navigator.keyboard.unlock();
       }
     },
     "download": function() {

--- a/index.js
+++ b/index.js
@@ -363,39 +363,55 @@ window.addEventListener("load", function() {
     },
     "fullscreen": function() {
       try {
-        if (document.fullscreenElement) {
-          document.exitFullscreen().then(
-            displayOutcome("fullscreen", "default")("exited with API"),
-            displayOutcome("fullscreen", "error"));
-          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")(document.fullscreenElement ? "fullscreenchanged enter" : "fullscreenchanged on exit"));
-          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error"));
-        } else {
+        if (!document.fullscreenElement) {
+          document.addEventListener("fullscreenchanged", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")("change event"));
+          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error event"));
           document.documentElement.requestFullscreen().then(
-            displayOutcome("fullscreen", "success")("entered"),
-            displayOutcome("fullscreen", "error"));
+            displayOutcome("fullscreen", "success")("enter"),
+            displayOutcome("fullscreen", "error")
+          );
+        } else {
+          document.exitFullscreen().then(
+            displayOutcome("fullscreen", "default")("exit"),
+            displayOutcome("fullscreen", "error")
+          );
         }
       } catch (e) {
         displayOutcome("fullscreen", "error")(e);
       }
     },
     "pointerlock": function() {
-      document.body.requestPointerLock(
-        /* no callback */
-      );
+      try {
+        if (!window.pointerLockRequested) {
+          window.pointerLockRequested = true;
+          document.addEventListener("pointerlockchange", displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default")("change event"));
+          document.addEventListener("pointerlockerror", displayOutcome("pointerlock", "error event"));
+          document.body.requestPointerLock().then(
+            displayOutcome("pointerlock", "success")("locked"),
+            displayOutcome("pointerlock", "error")
+          );
+        } else {
+          window.pointerLockRequested = false;
+          document.exitPointerLock();
+          displayOutcome("pointerlock", "default")("unlocked");
+        }
+      } catch (e) {
+        displayOutcome("pointerlock", "error")(e);
+      }
     },
     "keyboardlock": function() {
       try {
         if (!window.keyboardLockRequested) {
+          window.keyboardLockRequested = true;
           // Note: As of 2023-12-13, Chrome's promise may resolve before the lock takes effect during fullscreen.
           navigator.keyboard.lock().then(
-            displayOutcome("keyboardlock", "success")(document.fullscreenElement ? "Locked" : "Will lock in fullscreen"),
+            displayOutcome("keyboardlock", "success")(document.fullscreenElement ? "locked" : "will lock in fullscreen"),
             displayOutcome("keyboardlock", "error")
           );
-          window.keyboardLockRequested = true;
         } else {
+          window.keyboardLockRequested = false;
           navigator.keyboard.unlock();
           displayOutcome("keyboardlock", "default")("unlocked");
-          window.keyboardLockRequested = false;
         }
       } catch (e) {
         displayOutcome("keyboardlock", "error")(e);

--- a/index.js
+++ b/index.js
@@ -364,8 +364,8 @@ window.addEventListener("load", function() {
     "fullscreen": function() {
       try {
         if (!document.fullscreenElement) {
-          document.addEventListener("fullscreenchanged", (e) => { displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default")(e); });
-          document.addEventListener("fullscreenerror", (e) => { displayOutcome("fullscreen", "error")(e); });
+          document.addEventListener("fullscreenchange", displayOutcome("fullscreen", document.fullscreenElement ? "success" : "default"));
+          document.addEventListener("fullscreenerror", displayOutcome("fullscreen", "error"));
           document.documentElement.requestFullscreen().then(
             displayOutcome("fullscreen", "success")("enter"),
             displayOutcome("fullscreen", "error")
@@ -384,8 +384,8 @@ window.addEventListener("load", function() {
       try {
         if (!window.pointerLockRequested) {
           window.pointerLockRequested = true;
-          document.addEventListener("pointerlockchange", (e) => { displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default")(e); });
-          document.addEventListener("pointerlockerror", (e) => { displayOutcome("pointerlock", "error")(e); });
+          document.addEventListener("pointerlockchange", displayOutcome("pointerlock", window.pointerLockRequested ? "success" : "default"));
+          document.addEventListener("pointerlockerror", displayOutcome("pointerlock", "error"));
           document.body.requestPointerLock().then(
             displayOutcome("pointerlock", "success")("locked"),
             displayOutcome("pointerlock", "error")


### PR DESCRIPTION
Support toggling and display outcomes for Fullscreen, Pointer Lock, and Keyboard Lock API calls and events.
Add and refine use of prefixed identifiers; avoid `requestFullScreen` per crbug.com/1511367
Manually tested fairly thoroughly on Chrome 120.0.6099.71 and Firefox 115.5.0esr.
Feel free to test at https://michaelwasserman.github.io/permission.site/