### PR TITLE
Remove now unnecessary instructions

### DIFF
--- a/pepc.html
+++ b/pepc.html
@@ -17,18 +17,7 @@
       <div><permission id="camera-microphone" type="camera microphone"></div>
       <div class="demo-instructions">
         <h2>👩🏻‍💻 Demo instructions</h2>
-        You will see empty rectangles unless this browser implementes basic support for the &lt;permission&gt;&nbsp;element. In Chrome M121 or later, follow these instructions to enable experimental support:
-        <ul>
-          <li>Shut down the browser process.</li>
-          <li>
-            Restart the browser with these command line flag:
-            <pre>--enable-features=PermissionElement</pre>
-          </li>
-          <li>
-            Ensure the flags actually took effect by verifying they appear on:
-            <pre>chrome://version</pre>
-          </li>
-        </ul>
+        You will see empty rectangles unless this browser implementes basic support for the &lt;permission&gt;&nbsp;element.
       </div>
     </div>
     <div class="github-fork-ribbon-wrapper right">


### PR DESCRIPTION
The PECP example uses an OT token.