### PR TITLE
Add PlayReady HWDRM key system string

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,6 +279,7 @@ window.addEventListener("load", () => {
       var knownKeySystems = [
         "com.example.somesystem", // Ensure no real system is the first tried.
         "com.widevine.alpha",
+        "com.microsoft.playready",
         "com.microsoft.playready.recommendation.3000",
         "com.adobe.primetime",
         "com.apple.fps.2_0",


### PR DESCRIPTION
The PlayReady key system string should be updated to "com.microsoft.playready.recommendation.3000". This is to trigger the HWDRM permissions that PlayReady uses.