### PR TITLE
Add Generic Sensor API permission requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=0.6">
-  <!-- Origin trial token needed for Web USB -->
   <meta http-equiv="origin-trial"
     content="AsxscPRBb7U1KJIlQrsFrZ3ea0LHwRhNkbqBKsSuLP5y3sqIqnanjKbGk4oe5+/HkownaJhI2wP6m1S70Y8xkQsAAABUeyJvcmlnaW4iOiAiaHR0cHM6Ly9wZXJtaXNzaW9uLnNpdGU6NDQzIiwgImZlYXR1cmUiOiAiV2ViVVNCIiwgImV4cGlyeSI6IDE0NjUzODkxOTd9">
   <title>permission.site</title>
@@ -62,6 +61,22 @@
     <button id="orientation">Device Orientation</button>
     <button id="motion">Device Motion</button>
 
+    <hr>
+    
+    <button id="ambient-light-sensor">Ambient Light Sensor</button>
+    <button id="accelerometer">Accelerometer</button>
+    <button id="linear-acceleration-sensor">Linear Acceleration Sensor</button>
+    <button id="gravity-sensor">Gravity Sensor</button>
+    <button id="gyroscope">Gyroscope</button>
+    <button id="magnetometer">Magnetometer</button>
+    <button id="uncalibrated-magnetometer">Uncalibrated Magnetometer</button>
+    <button id="absolute-orientation-sensor">Absolute Orientation Sensor</button>
+    <button id="relative-orientation-sensor">Relative Orientation Sensor</button>
+    <button id="geolocation-sensor">Geolocation Sensor</button>
+    <button id="proximity-sensor">Proximity Sensor</button>
+
+    <hr>
+
     <button id="keygen">&lt;keygen&gt;</button>
     <div id="keygen-container"></div>
 
@@ -97,11 +112,15 @@
           <code>chrome://flags/#enable-experimental-web-platform-features</code>.</td>
       </tr>
       <tr>
+        <td>Generic Sensors (Proximity, etc.)</td>
+        <td>Some sensors may require enabling the 
+          <code>chrome://flags/#enable-generic-sensor-extra-classes</code> flag.</td>
+      </tr>
+      <tr>
         <td>Encrypted Media (EME)</td>
         <td>May succeed without permission depending on the implementation.<br>
           Attempts to use known key systems. (See the source for the list of supported key systems.)
-          <!-- Clear Key is not supported because it is not expected to require permissions. -->
-        </td>
+          </td>
       </tr>
       <tr>
         <td>Async Clipboard</td>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=0.6">
@@ -12,18 +11,14 @@
   <link rel="stylesheet" href="style.css">
   <script src="index.js"></script>
 </head>
-
 <body>
-
   <noscript>
     <div class="jswarning">
       This site does not function without JavaScript!
     </div>
   </noscript>
-
   <div class="before"></div>
   <div class="content">
-
     <div id="toggle-wrapper">
       <a id="toggle" class="neutral" href="" title="Switch between HTTP and HTTPS.">
         <span class="http">HTTP</span>
@@ -33,7 +28,6 @@
         <span class="https">HTTPS</span>
       </a>
     </div>
-
     <button id="notifications">Notifications</button>
     <button id="location">Location</button>
     <button id="camera">Camera</button>
@@ -60,9 +54,7 @@
     <button id="ar">Augmented Reality (AR)</button>
     <button id="orientation">Device Orientation</button>
     <button id="motion">Device Motion</button>
-
     <hr>
-    
     <button id="ambient-light-sensor">Ambient Light Sensor</button>
     <button id="accelerometer">Accelerometer</button>
     <button id="linear-acceleration-sensor">Linear Acceleration Sensor</button>
@@ -74,35 +66,25 @@
     <button id="relative-orientation-sensor">Relative Orientation Sensor</button>
     <button id="geolocation-sensor">Geolocation Sensor</button>
     <button id="proximity-sensor">Proximity Sensor</button>
-
     <hr>
-
     <button id="keygen">&lt;keygen&gt;</button>
     <div id="keygen-container"></div>
-
     <hr>
-
     <button id="fullscreen">Fullscreen</button>
     <button id="pointerlock">Pointer Lock</button>
     <button id="keyboardlock">Keyboard Lock</button>
-
     <hr>
-
     <button id="copy">Copy</button>
     <button id="download">Auto Download</button>
     <button id="popup">Popup</button>
     <button id="popup-delayed">Popup (delayed 5 seconds)</button>
-
     <hr>
-
     <p>Async Clipboard API</p>
-
     <button id="read-text">Read text</button>
     <button id="write-text">Write text</button>
     <br>
     <button id="read-text-delayed">Read text (delayed)</button>
     <button id="write-text-delayed">Write text (delayed)</button>
-
     <br><br><br>
     <p>Notes:</p>
     <table>
@@ -152,17 +134,13 @@
         </td>
       </tr>
     </table>
-
   </div>
   <div class="after"></div>
-
   <div class="github-fork-ribbon-wrapper right">
     <div class="github-fork-ribbon">
       <a href="https://github.com/chromium/permission.site">On GitHub</a>
     </div>
   </div>
   <link rel="stylesheet" href="third_party/github.css">
-
 </body>
-
 </html>

--- a/index.js
+++ b/index.js
@@ -80,6 +80,38 @@ window.addEventListener("load", () => {
     );
   }
 
+  // Generic Sensor Helper
+  function testGenericSensor(SensorClass, id) {
+    return () => {
+      try {
+        if (!SensorClass) {
+          // If the class is undefined (e.g. ProximitySensor not enabled), report error
+          displayOutcome(
+            id,
+            "error",
+          )("Sensor API not available (check flags?)");
+          return;
+        }
+
+        const sensor = new SensorClass();
+        sensor.onerror = (event) => {
+          if (event.error.name === "NotAllowedError") {
+            displayOutcome(id, "denied")(event.error.message);
+          } else {
+            displayOutcome(id, "error")(event.error.message, event.error.name);
+          }
+        };
+        sensor.onreading = () => {
+          displayOutcome(id, "success")("Reading retrieved");
+          sensor.stop();
+        };
+        sensor.start();
+      } catch (e) {
+        displayOutcome(id, "error")(e.message || e);
+      }
+    };
+  }
+
   navigator.getUserMedia =
     navigator.getUserMedia ||
     navigator.webkitGetUserMedia ||
@@ -866,6 +898,40 @@ window.addEventListener("load", () => {
         displayOutcome("motion", "error")("Device Motion is not supported");
       }
     },
+
+    // Generic Sensor API entries
+    "ambient-light-sensor": testGenericSensor(
+      window.AmbientLightSensor,
+      "ambient-light-sensor",
+    ),
+    accelerometer: testGenericSensor(window.Accelerometer, "accelerometer"),
+    "linear-acceleration-sensor": testGenericSensor(
+      window.LinearAccelerationSensor,
+      "linear-acceleration-sensor",
+    ),
+    "gravity-sensor": testGenericSensor(window.GravitySensor, "gravity-sensor"),
+    gyroscope: testGenericSensor(window.Gyroscope, "gyroscope"),
+    magnetometer: testGenericSensor(window.Magnetometer, "magnetometer"),
+    "uncalibrated-magnetometer": testGenericSensor(
+      window.UncalibratedMagnetometer,
+      "uncalibrated-magnetometer",
+    ),
+    "absolute-orientation-sensor": testGenericSensor(
+      window.AbsoluteOrientationSensor,
+      "absolute-orientation-sensor",
+    ),
+    "relative-orientation-sensor": testGenericSensor(
+      window.RelativeOrientationSensor,
+      "relative-orientation-sensor",
+    ),
+    "geolocation-sensor": testGenericSensor(
+      window.GeolocationSensor,
+      "geolocation-sensor",
+    ),
+    "proximity-sensor": testGenericSensor(
+      window.ProximitySensor,
+      "proximity-sensor",
+    ),
   };
 
   for (var type in register) {


### PR DESCRIPTION
This PR implements permission requests for the Generic Sensor APIs as requested in issue #97 .

Changes:
- Added buttons for 11 generic sensors (AmbientLight, Accelerometer, Gyroscope, Magnetometer, etc.) to `index.html`.
- Updated `index.js` with a helper function `testGenericSensor` to handle the instantiation and event listeners for these sensors.
- Added a note in the UI regarding browser flags required for experimental sensors like ProximitySensor.

Fixes #97 