### PR TITLE
Make `<geolocation>` logger colors work in dark and light mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -252,8 +252,9 @@ geolocation:hover {
   font-family: monospace;
   border: 1px solid #ddd;
   padding: 15px;
-  margin-top: 10px;
-  background-color: #fafafa;
+  margin-top: 10px;  
+  color: light-dark(#000, #fafafa);  
+  background-color: light-dark(#fafafa, #000);
   min-height: 80px;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Before:

<img width="183" height="187" alt="Screenshot 2026-01-21 at 12 56 12" src="https://github.com/user-attachments/assets/2caf3e3a-22f5-421c-802f-ca029a2744f7" />

After:

<img width="177" height="184" alt="Screenshot 2026-01-21 at 12 55 21" src="https://github.com/user-attachments/assets/5596d1d3-5bb4-45e3-afde-88e07d465b3f" />
<img width="181" height="184" alt="Screenshot 2026-01-21 at 12 55 34" src="https://github.com/user-attachments/assets/54f7e4a0-4686-4d8d-a007-f3db41a6582d" />
