### PR TITLE
Add demo html for media capture element

### DIFF
--- a/media_capture_element.html
+++ b/media_capture_element.html
@@ -12,6 +12,14 @@
     <div class="before"></div>
     <div class="content">
       <h1>Media Capture Elements Demo</h1>
+
+      <div id="mode-toggle-wrapper" class="mode-toggle-box">
+        <p>
+          <strong>Current Mode:</strong>
+          <span id="mode-indicator" style="font-weight: 800;">STANDARD</span>
+        </p>
+        <button id="toggle-ot-btn">Enable Legacy Mode (OT)</button>
+      </div>
       
       <h2>1. Media Capture Elements</h2>
       <p>Click these elements to request media with different constraints (no <code>type</code> attribute).</p>

--- a/media_capture_element.html
+++ b/media_capture_element.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=0.6" />
+    <title>permission.site (media capture elements)</title>
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" href="app-icon.png" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="before"></div>
+    <div class="content">
+      <h1>Media Capture Elements Demo</h1>
+      
+      <h2>1. Media Capture Elements</h2>
+      <p>Click these elements to request media with different constraints (no <code>type</code> attribute).</p>
+      <div>
+        <span class="permission-element-box">
+          <usermedia id="um-both" tabindex="0">No Usermedia Element</usermedia>
+        </span>
+        <span class="permission-element-box">
+          <camera id="cam-element" tabindex="0">No Camera Element</camera>
+        </span>
+        <span class="permission-element-box">
+          <microphone id="mic-element" tabindex="0">No Microphone Element</microphone>
+        </span>
+      </div>
+
+      <h2>2. Legacy &lt;usermedia&gt; Element</h2>
+      <p>Click these elements to request media using the legacy <code>type</code> attribute (acting like permission elements).</p>
+      <div>
+        <span class="permission-element-box">
+          <usermedia id="um-legacy-audio" type="microphone" tabindex="0">No Usermedia Element</usermedia>
+        </span>
+        <span class="permission-element-box">
+          <usermedia id="um-legacy-video" type="camera" tabindex="0">No Usermedia Element</usermedia>
+        </span>
+        <span class="permission-element-box">
+          <usermedia id="um-legacy-both" type="camera microphone" tabindex="0">No Usermedia Element</usermedia>
+        </span>
+      </div>
+
+      <div class="media-display-container">
+        <h3>Live Preview</h3>
+        <video id="video-feed" class="media-video-feed" autoplay muted playsinline></video>
+        
+        <div id="volume-meter-container" class="volume-meter-container">
+          <label for="volume-meter-bar">🎤 Microphone Input Level:</label>
+          <div class="volume-meter-bg">
+            <div id="volume-meter-bar" class="volume-meter-bar"></div>
+          </div>
+        </div>
+
+        <h3>Event Logs</h3>
+        <div id="log-output" class="media-event-logger">Waiting for user interaction...</div>
+      </div>
+      
+      <div class="demo-instructions">
+        <h2>👩🏻‍💻 Demo Instructions</h2>
+        <p>By default, standard media capture elements are enabled starting in Chrome M151.</p>
+        <p>To test the <strong>legacy usermedia mode</strong> (with the <code>type</code> attribute), you need to enable the legacy support experiment:</p>
+        <ul>
+          <li>Go to <code>chrome://flags</code> and enable the <strong>UserMediaElementLegacy</strong> flag.</li>
+          <li>Alternatively, shut down the browser process and restart it with the command line flag:
+            <pre>--enable-features=UserMediaElementLegacy</pre>
+          </li>
+          <li>Or register for the <strong>UserMediaElement</strong> Origin Trial (OT) to enable legacy support on your origin.</li>
+          <li>
+            Ensure the flag took effect by verifying it appears on:
+            <pre>chrome://version</pre>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="after"></div>
+
+    <div class="github-fork-ribbon-wrapper right">
+      <div class="github-fork-ribbon">
+        <a href="https://github.com/chromium/permission.site">On GitHub</a>
+      </div>
+    </div>
+    <link rel="stylesheet" href="third_party/github.css" />
+
+    <script src="./media_capture_element.js"></script>
+  </body>
+</html>

--- a/media_capture_element.html
+++ b/media_capture_element.html
@@ -7,6 +7,19 @@
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="app-icon.png" />
     <link rel="stylesheet" href="style.css" />
+    <script>
+      (function() {
+        const OT_TOKEN =
+          "As0h1KZNvjE/ahZ5XIjLEylA1lNDTQ+VFANatlPIrPi5fntBf9nZPUBNeIbHvOupoy1hXWZYE4q4rniDLGWSuAoAAABseyJvcmlnaW4iOiJodHRwczovL3Blcm1pc3Npb24uc2l0ZTo0NDMiLCJmZWF0dXJlIjoiVXNlck1lZGlhRWxlbWVudCIsImV4cGlyeSI6MTc5MDAzNTIwMCwiaXNTdWJkb21haW4iOnRydWV9";
+        const isLegacy = sessionStorage.getItem("legacyModeActive") === "true";
+        if (isLegacy) {
+          const meta = document.createElement("meta");
+          meta.setAttribute("http-equiv", "origin-trial");
+          meta.setAttribute("content", OT_TOKEN);
+          document.head.appendChild(meta);
+        }
+      })();
+    </script>
   </head>
   <body>
     <div class="before"></div>
@@ -54,7 +67,7 @@
         <video id="video-feed" class="media-video-feed" autoplay muted playsinline></video>
         
         <div id="volume-meter-container" class="volume-meter-container">
-          <label for="volume-meter-bar">🎤 Microphone Input Level:</label>
+          <span>Microphone Input Level:</span>
           <div class="volume-meter-bg">
             <div id="volume-meter-bar" class="volume-meter-bar"></div>
           </div>

--- a/media_capture_element.js
+++ b/media_capture_element.js
@@ -210,25 +210,6 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  function initializeOriginTrial() {
-    const isLegacy = sessionStorage.getItem("legacyModeActive") === "true";
-    let meta = document.querySelector('meta[http-equiv="origin-trial"]');
-
-    if (isLegacy) {
-      if (!meta) {
-        meta = document.createElement("meta");
-        meta.setAttribute("http-equiv", "origin-trial");
-        meta.setAttribute("content", OT_TOKEN);
-        document.head.appendChild(meta);
-      }
-    } else {
-      if (meta && meta.getAttribute("content") === OT_TOKEN) {
-        meta.remove();
-      }
-    }
-    updateModeUI();
-  }
-
   function toggleOriginTrial() {
     const isLegacy = sessionStorage.getItem("legacyModeActive") === "true";
     if (isLegacy) {
@@ -245,7 +226,7 @@ window.addEventListener("DOMContentLoaded", () => {
   }
 
   // Initialize on load based on stored session state
-  initializeOriginTrial();
+  updateModeUI();
 
   logOutput.innerHTML = "";
   log("System ready. Click elements above to test.", "info");

--- a/media_capture_element.js
+++ b/media_capture_element.js
@@ -192,6 +192,61 @@ window.addEventListener("DOMContentLoaded", () => {
     el.addEventListener("cancel", () => handleCancel("Listener:cancel"));
   }
 
+  const OT_TOKEN =
+    "As0h1KZNvjE/ahZ5XIjLEylA1lNDTQ+VFANatlPIrPi5fntBf9nZPUBNeIbHvOupoy1hXWZYE4q4rniDLGWSuAoAAABseyJvcmlnaW4iOiJodHRwczovL3Blcm1pc3Npb24uc2l0ZTo0NDMiLCJmZWF0dXJlIjoiVXNlck1lZGlhRWxlbWVudCIsImV4cGlyeSI6MTc5MDAzNTIwMCwiaXNTdWJkb21haW4iOnRydWV9";
+  const toggleOtBtn = document.getElementById("toggle-ot-btn");
+  const modeIndicator = document.getElementById("mode-indicator");
+
+  function updateModeUI() {
+    const meta = document.querySelector('meta[http-equiv="origin-trial"]');
+    const hasToken = meta && meta.getAttribute("content") === OT_TOKEN;
+
+    if (hasToken) {
+      modeIndicator.textContent = "LEGACY (ORIGIN TRIAL ACTIVE)";
+      toggleOtBtn.textContent = "Disable Legacy Mode (OT)";
+    } else {
+      modeIndicator.textContent = "STANDARD";
+      toggleOtBtn.textContent = "Enable Legacy Mode (OT)";
+    }
+  }
+
+  function initializeOriginTrial() {
+    const isLegacy = sessionStorage.getItem("legacyModeActive") === "true";
+    let meta = document.querySelector('meta[http-equiv="origin-trial"]');
+
+    if (isLegacy) {
+      if (!meta) {
+        meta = document.createElement("meta");
+        meta.setAttribute("http-equiv", "origin-trial");
+        meta.setAttribute("content", OT_TOKEN);
+        document.head.appendChild(meta);
+      }
+    } else {
+      if (meta && meta.getAttribute("content") === OT_TOKEN) {
+        meta.remove();
+      }
+    }
+    updateModeUI();
+  }
+
+  function toggleOriginTrial() {
+    const isLegacy = sessionStorage.getItem("legacyModeActive") === "true";
+    if (isLegacy) {
+      sessionStorage.setItem("legacyModeActive", "false");
+    } else {
+      sessionStorage.setItem("legacyModeActive", "true");
+    }
+    // Reload is required for Chrome to re-evaluate the Origin Trial state and register the custom HTML elements.
+    window.location.reload();
+  }
+
+  if (toggleOtBtn) {
+    toggleOtBtn.addEventListener("click", toggleOriginTrial);
+  }
+
+  // Initialize on load based on stored session state
+  initializeOriginTrial();
+
   logOutput.innerHTML = "";
   log("System ready. Click elements above to test.", "info");
 

--- a/media_capture_element.js
+++ b/media_capture_element.js
@@ -77,14 +77,19 @@ window.addEventListener("DOMContentLoaded", () => {
       draw();
     } catch (e) {
       console.error("Web Audio API error: ", e);
-      log(`Failed to initialize Web Audio level visualization: ${e.message}`, "error");
+      log(
+        `Failed to initialize Web Audio level visualization: ${e.message}`,
+        "error",
+      );
     }
   }
 
   function clearCurrentStream() {
     stopAudioVisualization();
     if (currentStream) {
-      currentStream.getTracks().forEach((track) => track.stop());
+      currentStream.getTracks().forEach((track) => {
+        track.stop();
+      });
       videoPreview.srcObject = null;
       currentStream = null;
       log("Previous stream tracks stopped and cleared.", "info");
@@ -111,14 +116,12 @@ window.addEventListener("DOMContentLoaded", () => {
             clearCurrentStream();
             currentStream = stream;
             videoPreview.srcObject = currentStream;
-            
             const vTracks = currentStream.getVideoTracks().length;
             const aTracks = currentStream.getAudioTracks().length;
             log(
               `${testName} Success! Stream acquired (Video tracks: ${vTracks}, Audio tracks: ${aTracks})`,
               "success",
             );
-            
             // Start audio level visualizer if microphone is active
             visualizeAudio(currentStream);
           })
@@ -153,16 +156,11 @@ window.addEventListener("DOMContentLoaded", () => {
         clearCurrentStream();
         currentStream = el.stream;
         videoPreview.srcObject = currentStream;
-        
         // Start audio level visualizer if microphone is active
         visualizeAudio(currentStream);
       }
-      const vTracks = currentStream
-        ? currentStream.getVideoTracks().length
-        : 0;
-      const aTracks = currentStream
-        ? currentStream.getAudioTracks().length
-        : 0;
+      const vTracks = currentStream ? currentStream.getVideoTracks().length : 0;
+      const aTracks = currentStream ? currentStream.getAudioTracks().length : 0;
       log(
         `[${sourceName}] ${testName} Success! Stream acquired (Video tracks: ${vTracks}, Audio tracks: ${aTracks})`,
         "success",

--- a/media_capture_element.js
+++ b/media_capture_element.js
@@ -1,0 +1,231 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const videoPreview = document.getElementById("video-feed");
+  const logOutput = document.getElementById("log-output");
+  let currentStream = null;
+
+  // Web Audio variables for mic level visualization
+  let audioCtx = null;
+  let analyser = null;
+  let source = null;
+  let animationId = null;
+
+  function log(message, type = "info") {
+    const entry = document.createElement("div");
+    entry.className = `log-entry ${type}`;
+    const time = new Date().toLocaleTimeString();
+    entry.textContent = `[${time}] ${message}`;
+    logOutput.appendChild(entry);
+    logOutput.scrollTop = logOutput.scrollHeight;
+  }
+
+  function stopAudioVisualization() {
+    if (animationId) {
+      cancelAnimationFrame(animationId);
+      animationId = null;
+    }
+    if (source) {
+      source.disconnect();
+      source = null;
+    }
+    if (audioCtx) {
+      audioCtx.close();
+      audioCtx = null;
+    }
+    const volumeContainer = document.getElementById("volume-meter-container");
+    if (volumeContainer) {
+      volumeContainer.style.display = "none";
+    }
+  }
+
+  function visualizeAudio(stream) {
+    if (!stream || stream.getAudioTracks().length === 0) {
+      return;
+    }
+
+    try {
+      audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      analyser = audioCtx.createAnalyser();
+      source = audioCtx.createMediaStreamSource(stream);
+      source.connect(analyser);
+
+      analyser.fftSize = 256;
+      const bufferLength = analyser.frequencyBinCount;
+      const dataArray = new Uint8Array(bufferLength);
+
+      const volumeMeter = document.getElementById("volume-meter-bar");
+      const volumeContainer = document.getElementById("volume-meter-container");
+      if (volumeContainer) {
+        volumeContainer.style.display = "block";
+      }
+
+      function draw() {
+        if (!audioCtx) return;
+        animationId = requestAnimationFrame(draw);
+        analyser.getByteFrequencyData(dataArray);
+
+        let total = 0;
+        for (let i = 0; i < bufferLength; i++) {
+          total += dataArray[i];
+        }
+        const average = total / bufferLength;
+
+        if (volumeMeter) {
+          volumeMeter.style.width = Math.min(100, (average / 128) * 100) + "%";
+        }
+      }
+
+      draw();
+    } catch (e) {
+      console.error("Web Audio API error: ", e);
+      log(`Failed to initialize Web Audio level visualization: ${e.message}`, "error");
+    }
+  }
+
+  function clearCurrentStream() {
+    stopAudioVisualization();
+    if (currentStream) {
+      currentStream.getTracks().forEach((track) => track.stop());
+      videoPreview.srcObject = null;
+      currentStream = null;
+      log("Previous stream tracks stopped and cleared.", "info");
+    }
+  }
+
+  // --- Legacy Setup (behaving like PEPC) ---
+  function setupLegacyElement(el, testName, constraints) {
+    if (!el) return;
+
+    const handlePermissionChange = (event) => {
+      log(
+        `[Legacy Event:${event.type}] ${testName} permissionStatus: ${el.permissionStatus}`,
+        "info",
+      );
+      if (el.permissionStatus === "granted") {
+        log(
+          `${testName} Permission granted. Requesting getUserMedia...`,
+          "info",
+        );
+        navigator.mediaDevices
+          .getUserMedia(constraints)
+          .then((stream) => {
+            clearCurrentStream();
+            currentStream = stream;
+            videoPreview.srcObject = currentStream;
+            
+            const vTracks = currentStream.getVideoTracks().length;
+            const aTracks = currentStream.getAudioTracks().length;
+            log(
+              `${testName} Success! Stream acquired (Video tracks: ${vTracks}, Audio tracks: ${aTracks})`,
+              "success",
+            );
+            
+            // Start audio level visualizer if microphone is active
+            visualizeAudio(currentStream);
+          })
+          .catch((err) => {
+            log(
+              `${testName} getUserMedia Failed: ${err.name} - ${err.message}`,
+              "error",
+            );
+          });
+      }
+    };
+
+    el.addEventListener("promptaction", handlePermissionChange);
+    el.addEventListener("promptdismiss", handlePermissionChange);
+  }
+
+  // --- Media Capture Setup (onstream, onerror, oncancel) ---
+  function setupMediaCaptureElement(el, testName, constraints) {
+    if (!el) return;
+
+    if (constraints && typeof el.setConstraints === "function") {
+      el.setConstraints(constraints);
+      log(
+        `Constraints set for ${testName}: ${JSON.stringify(constraints)}`,
+        "info",
+      );
+    }
+
+    const handleSuccess = (sourceName) => {
+      // Prevent duplicate preview binding if both properties and listeners fire
+      if (currentStream !== el.stream) {
+        clearCurrentStream();
+        currentStream = el.stream;
+        videoPreview.srcObject = currentStream;
+        
+        // Start audio level visualizer if microphone is active
+        visualizeAudio(currentStream);
+      }
+      const vTracks = currentStream
+        ? currentStream.getVideoTracks().length
+        : 0;
+      const aTracks = currentStream
+        ? currentStream.getAudioTracks().length
+        : 0;
+      log(
+        `[${sourceName}] ${testName} Success! Stream acquired (Video tracks: ${vTracks}, Audio tracks: ${aTracks})`,
+        "success",
+      );
+    };
+
+    const handleFailure = (sourceName) => {
+      log(
+        `[${sourceName}] ${testName} Failed: ${el.error?.name || "Unknown Error"}`,
+        "error",
+      );
+    };
+
+    const handleCancel = (sourceName) => {
+      log(
+        `[${sourceName}] ${testName} Cancelled: Permission prompt dismissed/cancelled.`,
+        "info",
+      );
+    };
+
+    // Register via properties (onstream, onerror, oncancel)
+    el.onstream = () => handleSuccess("Property:onstream");
+    el.onerror = () => handleFailure("Property:onerror");
+    el.oncancel = () => handleCancel("Property:oncancel");
+
+    // Register via event listeners
+    el.addEventListener("stream", () => handleSuccess("Listener:stream"));
+    el.addEventListener("error", () => handleFailure("Listener:error"));
+    el.addEventListener("cancel", () => handleCancel("Listener:cancel"));
+  }
+
+  logOutput.innerHTML = "";
+  log("System ready. Click elements above to test.", "info");
+
+  // Setup Media Capture elements
+  setupMediaCaptureElement(
+    document.getElementById("um-both"),
+    "Usermedia (Camera & Mic)",
+    { audio: {}, video: {} },
+  );
+  setupMediaCaptureElement(
+    document.getElementById("cam-element"),
+    "Camera Only",
+  );
+  setupMediaCaptureElement(
+    document.getElementById("mic-element"),
+    "Microphone Only",
+  );
+
+  // Setup Legacy elements
+  setupLegacyElement(
+    document.getElementById("um-legacy-audio"),
+    "Legacy Usermedia (Microphone)",
+    { audio: {}, video: false },
+  );
+  setupLegacyElement(
+    document.getElementById("um-legacy-video"),
+    "Legacy Usermedia (Camera)",
+    { audio: false, video: {} },
+  );
+  setupLegacyElement(
+    document.getElementById("um-legacy-both"),
+    "Legacy Usermedia (Camera & Mic)",
+    { audio: {}, video: {} },
+  );
+});

--- a/style.css
+++ b/style.css
@@ -286,7 +286,11 @@ microphone {
 usermedia:hover,
 camera:hover,
 microphone:hover {
-  background-color: color-mix(in oklab, currentColor 10%, var(--button-background-color));
+  background-color: color-mix(
+    in oklab,
+    currentColor 10%,
+    var(--button-background-color)
+  );
 }
 
 .media-display-container {
@@ -354,5 +358,3 @@ microphone:hover {
   background-color: #1ac222;
   transition: width 0.05s ease;
 }
-
-

--- a/style.css
+++ b/style.css
@@ -358,3 +358,26 @@ microphone:hover {
   background-color: #1ac222;
   transition: width 0.05s ease;
 }
+
+.mode-toggle-box {
+  margin: 1.5em auto 2.5em;
+  padding: 1em;
+  border: 1px dashed #aaa;
+  max-width: 640px;
+  border-radius: 5px;
+  background-color: var(--button-background-color);
+  text-align: center;
+}
+
+.mode-toggle-box p {
+  margin: 0 0 1em;
+  font-size: 1.1em;
+}
+
+.mode-toggle-box button {
+  width: auto;
+  font-size: 1em;
+  padding: 6px 12px;
+  margin: 0;
+}
+

--- a/style.css
+++ b/style.css
@@ -266,3 +266,93 @@ geolocation:hover {
   min-height: 80px;
   white-space: pre-wrap;
 }
+
+usermedia,
+camera,
+microphone {
+  display: inline-block;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: var(--button-background-color);
+  color: currentColor;
+  cursor: pointer;
+  user-select: none;
+  font-weight: bold;
+  margin: 10px;
+  transition: background-color 0.2s;
+}
+
+usermedia:hover,
+camera:hover,
+microphone:hover {
+  background-color: color-mix(in oklab, currentColor 10%, var(--button-background-color));
+}
+
+.media-display-container {
+  margin: 20px auto;
+  max-width: 640px;
+}
+
+.media-video-feed {
+  width: 100%;
+  height: 360px;
+  background-color: #000;
+  border: 2px solid #ccc;
+  border-radius: 5px;
+}
+
+.media-event-logger {
+  font-family: monospace;
+  border: 1px solid #ddd;
+  padding: 15px;
+  margin-top: 10px;
+  background-color: var(--button-background-color);
+  min-height: 120px;
+  max-height: 250px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  text-align: left;
+}
+
+.media-event-logger .log-entry {
+  margin: 4px 0;
+}
+
+.media-event-logger .success {
+  color: #1ac222;
+}
+
+.media-event-logger .error {
+  color: #db4437;
+}
+
+.media-event-logger .info {
+  color: #2192ef;
+}
+
+.volume-meter-container {
+  display: none;
+  margin: 15px auto;
+  max-width: 640px;
+  text-align: left;
+}
+
+.volume-meter-bg {
+  width: 100%;
+  height: 20px;
+  background-color: var(--main-background-color);
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  overflow: hidden;
+  margin-top: 5px;
+}
+
+.volume-meter-bar {
+  width: 0%;
+  height: 100%;
+  background-color: #1ac222;
+  transition: width 0.05s ease;
+}
+
+

--- a/style.css
+++ b/style.css
@@ -380,4 +380,3 @@ microphone:hover {
   padding: 6px 12px;
   margin: 0;
 }
-


### PR DESCRIPTION
We kicked off the media capture elements implementation https://w3c.github.io/mediacapture-extensions/#media-capture-html-elements and I would like to add a public test site for this.

The old site is pepc.html will be deprecated