### PR TITLE
Move the geolocation contrast fix into style.css and tidy the demo page

### DIFF
--- a/geolocation_element.html
+++ b/geolocation_element.html
@@ -9,47 +9,10 @@
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="app-icon.png" />
     <link rel="stylesheet" href="style.css" />
-    <style>
-      /* Maximum contrast between page background and foreground: pure black on
-         pure white in light mode, pure white on pure black in dark mode. Both
-         are a 21:1 contrast ratio, the highest sRGB allows. */
-      :root {
-        --main-background-color: #fff;
-        --button-background-color: #fff;
-        --main-foreground-color: #000;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --main-background-color: #000;
-          --button-background-color: #000;
-          --main-foreground-color: #fff;
-        }
-      }
-
-      body {
-        color: var(--main-foreground-color);
-      }
-
-      geolocation,
-      .geolocation-event-logger,
-      .instructions,
-      pre,
-      code {
-        background-color: var(--main-background-color);
-        color: var(--main-foreground-color);
-        border-color: currentColor;
-      }
-
-      /* Invert on hover, which keeps the same 21:1 ratio. */
-      geolocation:hover {
-        background-color: var(--main-foreground-color);
-        color: var(--main-background-color);
-      }
-    </style>
   </head>
   <body>
-    <div class="container">
+    <div class="before"></div>
+    <div class="content">
       <h1>Geolocation Element Demo</h1>
       <h2>1. Manual Location Request</h2>
       <p>Click the element below to request the current location.</p>
@@ -78,15 +41,15 @@
         Geolocation watch element is not supported
       </geolocation>
       <div id="watch-output" class="geolocation-event-logger">Waiting for location updates...</div>
-      
-      <div class="instructions">
-        <h3>Demo Instructions</h3>
+
+      <div class="demo-instructions">
+        <h2>Demo instructions</h2>
         <p>In Chrome M143 or later, go to <code>chrome://flags#geolocation-element</code> and enable the experiment.</p>
         <p>Alternatively, follow these instructions to enable experimental support:</p>
         <ul>
           <li>Shut down the browser process.</li>
           <li>
-            Restart the browser with these command line flag:
+            Restart the browser with this command line flag:
             <pre>--enable-features=PermissionElement,GeolocationElement</pre>
           </li>
           <li>
@@ -96,6 +59,7 @@
         </ul>
       </div>
     </div>
+    <div class="after"></div>
     <div class="github-fork-ribbon-wrapper right">
       <div class="github-fork-ribbon">
         <a href="https://github.com/chromium/permission.site">On GitHub</a>

--- a/style.css
+++ b/style.css
@@ -1,14 +1,11 @@
 :root {
   color-scheme: light dark;
-  --main-background-color: #eee;
-  --button-background-color: #fff;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --main-background-color: #222;
-    --button-background-color: #555;
-  }
+  --main-background-color: light-dark(#eee, #222);
+  --button-background-color: light-dark(#fff, #555);
+  /* Kept separate from the button colors so the hover state can stay legible
+     against `currentColor` text in both schemes. */
+  --geolocation-background-color: light-dark(#fff, #555);
+  --geolocation-hover-background-color: light-dark(#e0e0e0, #6b6b6b);
 }
 
 /* Light material design boilerplate. */
@@ -247,14 +244,14 @@ geolocation {
   padding: 8px 12px;
   border: 1px solid #ccc;
   border-radius: 4px;
-  background-color: var(--button-background-color);
+  background-color: var(--geolocation-background-color);
   color: currentColor;
   cursor: pointer;
   user-select: none;
 }
 
 geolocation:hover {
-  background-color: #e0e0e0;
+  background-color: var(--geolocation-hover-background-color);
 }
 
 .geolocation-event-logger {


### PR DESCRIPTION
Follow-up to #161, addressing @lgarron's review feedback there and @engedy's request to clean up the page.

The real bug was narrower than #161 treated it. `geolocation:hover` set an unconditional `background-color: #e0e0e0` while the text stayed `currentColor`, so in dark mode it was white on light grey — **1.32:1**. Nothing else on the page was actually broken, which matches @lgarron's point 3.

**Contrast (points 1–4)**

- The `<style>` block #161 added to `geolocation_element.html` is gone. No page-local overrides, and the page looks like every other page again.
- The element gets its own `--geolocation-background-color` and `--geolocation-hover-background-color` in `style.css` instead of reusing `--button-background-color`. Resting appearance is unchanged; only the dark-mode hover moves, `#e0e0e0` → `#6b6b6b` (5.33:1 against white).
- `:root` now uses `light-dark()` and the `@media (prefers-color-scheme: dark)` block is gone. One note on point 4: `light-dark()` wasn't actually used anywhere in the codebase yet — the existing pattern *was* the media query — so I converted the whole `:root` block rather than adding a second convention alongside it. Computed values are identical, so no page changes appearance. Happy to split that into its own PR if you'd rather keep this one to the bug.

**Page cleanup (@engedy)**

- The empty-looking bullets: the list inherited `text-align: center` from `body`, leaving the markers stranded at the far left. The page was reaching for `.container` and `.instructions`, neither of which exists in `style.css`. Switched to the shared `.before`/`.content`/`.after` wrappers and `.demo-instructions`, matching `pepc.html` and `media_capture_element.html`.
- `<h3>Demo Instructions</h3>` → `<h2>Demo instructions</h2>`; that section is a sibling of "3. Watch Location", not a child of it.
- "these command line flag" → "this command line flag". (Same typo is in `pepc.html`, left alone here.)

**Verified** in Chrome at both `prefers-color-scheme` values, measured with the WCAG formula:

| | light | dark |
|---|---|---|
| page | 18.1 | 15.91 |
| element | 21 | 7.46 |
| element hover | 15.91 | **5.33** (was 1.32) |

`index.html` still computes `#222`/`#555` in dark mode after the `light-dark()` conversion, i.e. no regression on the other pages. `npx biome check` is clean.

Sorry again about the brutalism.